### PR TITLE
Add a shim for malloc_usable_size (Apple included)

### DIFF
--- a/src/common.cpp
+++ b/src/common.cpp
@@ -26,7 +26,11 @@
 #include <clocale>
 #include <cerrno>
 #include <utime.h>
+#ifdef __APPLE__
+#include <malloc/malloc.h>
+#else
 #include <malloc.h>
+#endif
 #include <sys/uio.h>
 #include <syslog.h>
 #ifndef __APPLE__
@@ -417,7 +421,11 @@ void shim::add_stdlib_shimmed_symbols(std::vector<shim::shimmed_symbol> &list) {
 void shim::add_malloc_shimmed_symbols(std::vector<shim::shimmed_symbol> &list) {
     list.insert(list.end(), {
         {"malloc", ::malloc},
+#ifdef __APPLE__
+        {"malloc_usable_size", ::malloc_size},
+#else
         {"malloc_usable_size", ::malloc_usable_size},
+#endif
         {"free", ::free},
         {"calloc", ::calloc},
         {"realloc", ::realloc},

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -26,6 +26,7 @@
 #include <clocale>
 #include <cerrno>
 #include <utime.h>
+#include <malloc.h>
 #include <sys/uio.h>
 #include <syslog.h>
 #ifndef __APPLE__
@@ -416,6 +417,7 @@ void shim::add_stdlib_shimmed_symbols(std::vector<shim::shimmed_symbol> &list) {
 void shim::add_malloc_shimmed_symbols(std::vector<shim::shimmed_symbol> &list) {
     list.insert(list.end(), {
         {"malloc", ::malloc},
+        {"malloc_usable_size", ::malloc_usable_size},
         {"free", ::free},
         {"calloc", ::calloc},
         {"realloc", ::realloc},


### PR DESCRIPTION
I've forked the @bylaws pr at #7 to fulfill the requested change by @ChristopherHX 6 days ago.

I should note that I also don't know the correctness of my PR and I added the include bit based on these sources:
https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/malloc_size.3.html
https://www.unix.com/man-page/osx/3/malloc_size/

Merging this PR will automatically merge #7

Edits by maintainers are allowed