### PR TITLE
Fix utimensat macOS 10.12 or lower

### DIFF
--- a/src/common.cpp
+++ b/src/common.cpp
@@ -236,14 +236,6 @@ int shim::getrlimit(bionic::rlimit_resource res, bionic::rlimit *info) {
     return ret;
 }
 
-int shim::utimensat(int dirfd, const char *pathname, const struct timespec times[2], int flags) {
-#ifdef __APPLE__
-    return 0; // utimensat not available on all macOS versions
-#else
-    return ::utimensat(dirfd, pathname, times, flags);
-#endif
-}
-
 int shim::prctl(bionic::prctl_num opt, unsigned long a2, unsigned long a3, unsigned long a4, unsigned long a5) {
 #ifdef __linux__
     return ::prctl((int) opt, a2, a3, a4, a5);

--- a/src/stat.cpp
+++ b/src/stat.cpp
@@ -89,6 +89,15 @@ int shim::lstat(const char *path, bionic::stat *s) {
 
 #endif
 
+int shim::utimensat(int dirfd, const char *pathname, const struct timespec times[2], int flags) {
+#ifdef __APPLE__
+    if(!utimensat) {
+        return 0; // utimensat not available on macOS 10.12 or lower
+    }
+#endif
+    return ::utimensat(dirfd, pathname, times, flags);
+}
+
 void shim::add_stat_shimmed_symbols(std::vector<shimmed_symbol> &list) {
     list.insert(list.end(), {
         {"stat", IOREWRITE1(stat)},

--- a/src/stat.h
+++ b/src/stat.h
@@ -76,6 +76,8 @@ namespace shim {
 
     }
 
+    int utimensat(int dirfd, const char *pathname, const struct timespec times[2], int flags);
+
     int stat(const char *path, bionic::stat *s);
     int fstat(int fd, bionic::stat *s);
     int lstat(const char *path,bionic::stat *s);


### PR DESCRIPTION
The prototype where defined in the wrong place, resulting utimensat as a nullptr for macOS 10.12 => unresolved symbol utimensat ( linker ignores null symbols )