### PR TITLE
Support for older versions

### DIFF
--- a/src/common.cpp
+++ b/src/common.cpp
@@ -629,6 +629,7 @@ void shim::add_unistd_shimmed_symbols(std::vector<shim::shimmed_symbol> &list) {
         {"swab", ::swab},
         {"pathconf", ::pathconf},
         {"truncate", ::truncate},
+	{"fdatasync", ::fdatasync},
 
         /* Use our impl or fallback to system */
         {"ftruncate", WithErrnoUpdate(ftruncate)},


### PR DESCRIPTION
Add support for versions as early as 1.0 so you don't need a separate launcher
 - You cannot resize versions earlier than 1.12
 - Untested on macOS