### PR TITLE
Emulate positive dst for timezones like Dublin

### DIFF
--- a/src/common.cpp
+++ b/src/common.cpp
@@ -545,7 +545,73 @@ void shim::add_math_shimmed_symbols(std::vector<shim::shimmed_symbol> &list) {
     });
 }
 
+static bool hasNegativeDST() {
+    tm t;
+    time_t cur = time(nullptr);
+    localtime_r(&cur, &t);
+    time_t before = mktime(&t);
+    tm a = t;
+    t.tm_mon += 6;
+    time_t after = mktime(&t);
+    tm b = t;
+    if(a.tm_isdst == !b.tm_isdst) {
+        auto n0 = a.tm_isdst ? b.tm_gmtoff : a.tm_gmtoff;
+        auto n1 = b.tm_isdst ? b.tm_gmtoff : a.tm_gmtoff;
+        return n0 > n1;
+    }
+    return false;
+}
+
 void shim::add_time_shimmed_symbols(std::vector<shim::shimmed_symbol> &list) {
+    // fixup timezones like Europe/Dublin by reversing the tm_isdst field of the tm structure
+    // Microsoft Xbox Authentication Library for android doesn't work with negative DST behavior
+    if(hasNegativeDST()) {
+        list.insert(list.end(), {
+            /* sys/time.h */
+            {"gettimeofday", gettimeofday},
+
+            /* time.h */
+            {"clock", ::clock},
+            {"time", ::time},
+            {"difftime", ::difftime},
+            {"mktime", &detail::arg_rewrite_helper<decltype(::mktime)>::rewrite<::mktime>},
+            {"strftime", &detail::arg_rewrite_helper<decltype(::strftime)>::rewrite<::strftime>},
+            {"strptime", &detail::arg_rewrite_helper<decltype(::strptime)>::rewrite<::strptime>},
+            {"strftime_l", &detail::arg_rewrite_helper<decltype(::strftime_l)>::rewrite<::strftime_l>},
+            {"strptime_l", &detail::arg_rewrite_helper<decltype(::strptime_l)>::rewrite<::strptime_l>},
+            {"gmtime", ::gmtime},
+            {"gmtime_r", ::gmtime_r},
+            {"localtime", +[](const time_t* time) {
+                auto loc = ::localtime(time);
+                if(!loc) {
+                    return loc;
+                }
+                switch(loc->tm_isdst) {
+                        case 1: 
+                            loc->tm_isdst = 0;
+                            break;
+                        case 0:
+                            loc->tm_isdst = 1;
+                            break;
+                        default:
+                            break;
+                    }
+                return loc;
+            }},
+            {"localtime_r", &detail::arg_rewrite_helper<decltype(::localtime_r)>::rewrite<::localtime_r>},
+            {"asctime", &detail::arg_rewrite_helper<decltype(::asctime)>::rewrite<::asctime>},
+            {"ctime", ::ctime},
+            {"asctime_r", &detail::arg_rewrite_helper<decltype(::asctime_r)>::rewrite<::asctime_r>},
+            {"ctime_r", ::ctime_r},
+            {"tzname", ::tzname},
+            {"tzset", ::tzset},
+            {"daylight", &::daylight},
+            {"timezone", &::timezone},
+            {"nanosleep", ::nanosleep},
+            {"clock_gettime", clock_gettime},
+        });
+        return;
+    }
     list.insert(list.end(), {
         /* sys/time.h */
         {"gettimeofday", gettimeofday},


### PR DESCRIPTION
fixup timezones like Europe/Dublin by reversing the tm_isdst field of the tm structure
Microsoft Xbox Authentication Library for android doesn't work with negative DST behavior


Fixes https://github.com/minecraft-linux/mcpelauncher-manifest/issues/945
Fixes https://github.com/minecraft-linux/mcpelauncher-manifest/issues/927
Fixes https://github.com/flathub/io.mrarm.mcpelauncher/issues/129
Fixes https://github.com/minecraft-linux/mcpelauncher-manifest/issues/915
Fixes https://github.com/minecraft-linux/mcpelauncher-manifest/issues/910
