### PR TITLE
fix flatpak

### DIFF
--- a/src/common.cpp
+++ b/src/common.cpp
@@ -338,18 +338,18 @@ ssize_t shim::__read_chk(int fd, void *buf, size_t count, size_t buf_size) {
     return read(fd, buf, count);
 }
 
-static ssize_t __recvfrom_chk(int socket, void* buf, size_t len, size_t buf_size,
+ssize_t shim::__recvfrom_chk(int socket, void* buf, size_t len, size_t buf_size,
                        int flags, sockaddr* src_addr, socklen_t* addrlen) {
   return recvfrom(socket, buf, len, flags, src_addr, addrlen);
 }
 
-static ssize_t __sendto_chk(int socket, const void* buf, size_t len, size_t buflen,
+ssize_t shim::__sendto_chk(int socket, const void* buf, size_t len, size_t buflen,
                      int flags, const struct sockaddr* dest_addr,
                      socklen_t addrlen) {
   return sendto(socket, buf, len, flags, dest_addr, addrlen);
 }
 
-static ssize_t __write_chk(int fd, const void* buf, size_t count, size_t buf_size) {
+ssize_t shim::__write_chk(int fd, const void* buf, size_t count, size_t buf_size) {
   return write(fd, buf, count);
 }
 

--- a/src/common.h
+++ b/src/common.h
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <cstddef>
 #include <sys/types.h>
+#include <sys/socket.h>
 #include "argrewrite.h"
 #include "mallinfo.h"
 #include <stdarg.h>
@@ -125,6 +126,15 @@ namespace shim {
     int gettimeofday(bionic::timeval *tv, void *p);
 
     ssize_t __read_chk(int fd, void* buf, size_t count, size_t buf_size);
+
+    ssize_t __recvfrom_chk(int socket, void* buf, size_t len, size_t buf_size,
+                        int flags, sockaddr* src_addr, socklen_t* addrlen);
+
+    ssize_t __sendto_chk(int socket, const void* buf, size_t len, size_t buflen,
+                        int flags, const struct sockaddr* dest_addr,
+                        socklen_t addrlen);
+
+    ssize_t __write_chk(int fd, const void* buf, size_t count, size_t buf_size);
 
 #ifdef __APPLE__
     int fdatasync(int fildes);


### PR DESCRIPTION
```
/run/build/mcpelauncher-client/libc-shim/src/common.cpp:341:16: error: static declaration of '__recvfrom_chk' follows non-static declaration
static ssize_t __recvfrom_chk(int socket, void* buf, size_t len, size_t buf_size,
               ^
/usr/include/x86_64-linux-gnu/bits/socket2.h:44:16: note: previous declaration is here
extern ssize_t __recvfrom_chk (int __fd, void *__restrict __buf, size_t __n,
               ^
```