### PR TITLE
Implement openat and unlinkat

### DIFF
--- a/src/common.cpp
+++ b/src/common.cpp
@@ -420,6 +420,12 @@ long shim::fakesyscall(long sysno, ...) {
     return ENOSYS;
 }
 
+int shim::unlinkat(int dirfd, const char *pathname, int flags) {
+    int ret = ::unlinkat(dirfd, iorewrite0(pathname).data(), flags);
+    bionic::update_errno();
+    return ret;
+}
+
 int shim::isnan(double d) {
 	return std::isnan(d);
 }
@@ -682,6 +688,7 @@ void shim::add_unistd_shimmed_symbols(std::vector<shim::shimmed_symbol> &list) {
         {"symlink", WithErrnoUpdate(IOREWRITE2(::symlink))},
         {"readlink", WithErrnoUpdate(::readlink)},
         {"unlink", WithErrnoUpdate(IOREWRITE1(::unlink))},
+        {"unlinkat", unlinkat},
         {"rmdir", WithErrnoUpdate(IOREWRITE1(::rmdir))},
         {"gethostname", WithErrnoUpdate(::gethostname)},
         {"fsync", WithErrnoUpdate(::fsync)},

--- a/src/common.h
+++ b/src/common.h
@@ -147,6 +147,8 @@ namespace shim {
 
     ssize_t getrandom(void *buf, size_t len, unsigned int flags);
 
+    int unlinkat(int dirfd, const char *pathname, int flags);
+
     int isnan(double d);
 
     int utimensat(int dirfd, const char *pathname, const struct timespec times[2], int flags);

--- a/src/file_misc.h
+++ b/src/file_misc.h
@@ -55,6 +55,8 @@ namespace shim {
 
     int open(const char *pathname, bionic::file_status_flags flags, ...);
 
+    int openat(int dirfd, const char *pathname, bionic::file_status_flags flags, ...);
+
     int open_2(const char *pathname, bionic::file_status_flags flags);
 
     int open_3(const char *pathname, bionic::file_status_flags flags, int mode);


### PR DESCRIPTION
They are required for iostream to work with newer NDK versions