### PR TITLE
Export arc4random_buf to support 1.21.80.20

### DIFF
--- a/src/common.cpp
+++ b/src/common.cpp
@@ -449,8 +449,10 @@ int shim::isnan(double d) {
 	return std::isnan(d);
 }
 
-#ifndef HAS_ARC4RANDOM_BUF
 void shim::arc4random_buf(void* buf, size_t len) {
+#ifdef HAS_ARC4RANDOM_BUF
+    ::arc4random_buf(buf, len);
+#else
     // Using SYS_getrandom is a bit complex since it can be interrupted
     // or not supported. Even if we used SYS_getrandom, we would have to
     // fall back to an alternative strategy or error out if it failed.
@@ -464,6 +466,7 @@ void shim::arc4random_buf(void* buf, size_t len) {
         buf = (uint8_t*)buf + n;
         len -= n;
     }
+#endif
 }
 
 uint32_t shim::arc4random() {
@@ -471,7 +474,6 @@ uint32_t shim::arc4random() {
     shim::arc4random_buf(&u, sizeof(u));
     return u;
 }
-#endif
 
 void shim::add_common_shimmed_symbols(std::vector<shim::shimmed_symbol> &list) {
     list.insert(list.end(), {

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -441,6 +441,13 @@ int shim::isnan(double d) {
 	return std::isnan(d);
 }
 
+#ifdef __linux__
+void shim::arc4random_buf(void* buf, size_t len) {
+    // We could use glibc arc4random_buf iff we would target glibc 2.36
+    (void)syscall(SYS_getrandom, buf, len, 0);
+}
+#endif
+
 void shim::add_common_shimmed_symbols(std::vector<shim::shimmed_symbol> &list) {
     list.insert(list.end(), {
         {"__errno", bionic::get_errno},
@@ -631,6 +638,11 @@ void shim::add_time_shimmed_symbols(std::vector<shim::shimmed_symbol> &list) {
         {"ctime_r", ::ctime_r},
         {"tzname", ::tzname},
         {"tzset", ::tzset},
+#ifdef __linux__
+        {"arc4random_buf", shim::arc4random_buf},
+#else
+        {"arc4random_buf", ::arc4random_buf},
+#endif
 #ifndef __FreeBSD__
         {"daylight", &::daylight},
 #endif

--- a/src/common.h
+++ b/src/common.h
@@ -151,6 +151,10 @@ namespace shim {
 
     int isnan(double d);
 
+#ifdef __linux__
+    void arc4random_buf(void* buf, size_t len);
+#endif
+
     int utimensat(int dirfd, const char *pathname, const struct timespec times[2], int flags);
 
     void add_common_shimmed_symbols(std::vector<shimmed_symbol> &list);

--- a/src/common.h
+++ b/src/common.h
@@ -101,8 +101,6 @@ namespace shim {
 
     int sendfile(int src, int dst, bionic::off_t *offset, size_t count);
 
-    uint32_t arc4random();
-
     void *__memcpy_chk(void *dst, const void *src, size_t size, size_t max_len);
 
     void *__memmove_chk(void *dst, const void *src, size_t size, size_t max_len);
@@ -151,9 +149,9 @@ namespace shim {
 
     int isnan(double d);
 
-#ifdef __linux__
     void arc4random_buf(void* buf, size_t len);
-#endif
+
+    uint32_t arc4random();
 
     int utimensat(int dirfd, const char *pathname, const struct timespec times[2], int flags);
 


### PR DESCRIPTION
Alternative to #38 .

- Uses ::arc4random_buf from glibc 2.36+ or OSX
- Otherwise falls back to std::random_device.