### PR TITLE
Add __strlcpy_chk symbol for Minecraft 1.21.130.3+ compatibility

### DIFF
--- a/src/common.cpp
+++ b/src/common.cpp
@@ -356,6 +356,15 @@ char* shim::__strncpy_chk2(char* dst, const char* src, size_t n, size_t dst_len,
     return strncpy(dst, src, n);
 }
 
+size_t shim::__strlcpy_chk(char *dst, const char *src, size_t size,
+                           size_t max_len) {
+  if (size > max_len) {
+    fprintf(stderr, "detected copy past buffer size");
+    abort();
+  }
+  return bionic::strlcpy(dst, src, size);
+}
+
 int shim::sendfile(int src, int dst, bionic::off_t *offset, size_t count) {
     off_t c = offset ? (off_t)offset : 0;
 #ifdef __APPLE__
@@ -896,6 +905,7 @@ void shim::add_string_shimmed_symbols(std::vector<shim::shimmed_symbol> &list) {
         {"__strncat_chk", __strncat_chk},
         {"__strncpy_chk", __strncpy_chk},
         {"__strncpy_chk2", __strncpy_chk2},
+		{"__strlcpy_chk", __strlcpy_chk},
         {"strlcpy", bionic::strlcpy},
         {"strcspn", ::strcspn},
         {"strpbrk", (char *(*)(char *, const char *)) ::strpbrk},

--- a/src/common.h
+++ b/src/common.h
@@ -128,6 +128,8 @@ namespace shim {
 
     char* __strncpy_chk2(char* dst, const char* src, size_t n, size_t dst_len, size_t src_len);
 
+    size_t __strlcpy_chk(char *dst, const char *src, size_t size, size_t max_len);
+
     size_t ctype_get_mb_cur_max();
 
     int gettimeofday(bionic::timeval *tv, void *p);


### PR DESCRIPTION
Minecraft 1.21.130.3 uses libPlayFabMultiplayer.so which requires the __strlcpy_chk symbol from Bionic libc. Without it, the game fails to load:

`dlopenfailed: cannot locate symbol "__strlcpy_chk"`

This PR adds the missing implementation following the same pattern as other fortified functions (__memcpy_chk, __strcpy_chk , etc.).

Changes:

common.h : Added function declaration
common.cpp : Added implementation with bounds checking, registered in
add_string_shimmed_symbols

Tested with: Minecraft 1.21.130.3, 1.21.144, 1.21.131